### PR TITLE
Revert "Eliminate redundant verify-card template"

### DIFF
--- a/src/middleware/api/verify.ts
+++ b/src/middleware/api/verify.ts
@@ -50,7 +50,7 @@ router
                 manager: true
             }
         })
-        res.render('mixins/verify-card', {
+        res.render('components/verify-card', {
             player
         })
     })

--- a/views/components/verify-card.pug
+++ b/views/components/verify-card.pug
@@ -1,0 +1,8 @@
+include ../mixins/player-card
++player-card(player)
+    if player.doc != null
+        p
+            a(href="/verifications/" + player.doc target="_blank") View Verification
+    button(hx-put="/api/verify/" + player.id + "/ACCEPTED" hx-target="closest .player-card" hx-swap="outerHTML") Accept 
+    button(hx-put="/api/verify/" + player.id + "/REJECTED" hx-target="closest .player-card" hx-swap="outerHTML") Reject 
+    button(hx-delete="/api/verify/" + player.id hx-target="closest .player-card" hx-swap="outerHTML" hx-confirm="Are you sure you want to delete this player's registration?") Delete


### PR DESCRIPTION
This reverts commit 9fb939f648cdbceff301288d831af98b707d5d32.

Preparing for rejection reason selection, requires verification card modification.